### PR TITLE
fix backend-tests.yml

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -21,6 +21,8 @@ jobs:
       with:
         node-version: '16'
         cache: 'npm'
+        cache-dependency-path: ./backend/package-lock.json
+      
     - name: list files
       run: ls -la
       working-directory: ./backend

--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - jkutzfla-*
   pull_request:
     branches:
       - main


### PR DESCRIPTION
need to specify the path to ./backend/package-lock.json when using the npm cache in setup node.